### PR TITLE
tox.ini: Use coveralls.io

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+PyYAML
+coverage
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist = py26, py27, py32, py33, py34, pypy
 
 [testenv]
-commands = {envpython} setup.py test
-deps =
-    PyYAML
+commands =
+    py.test --cov panci
+    coveralls
+deps = -r{toxinidir}/test_requirements.txt


### PR DESCRIPTION
Use `pytest-cov` to measure coverage and upload to coveralls.io using `coveralls` module.
