### PR TITLE
Support tox.ini files with generative envlist

### DIFF
--- a/panci/toxconfig.py
+++ b/panci/toxconfig.py
@@ -1,5 +1,7 @@
 """Provides a ``ToxConfig`` class for operating on ``tox.ini`` files"""
 
+import subprocess
+
 try:
     # Python 2
     from ConfigParser import ConfigParser
@@ -14,7 +16,7 @@ class ToxConfig(object):
     """Class for operating on ``tox.ini`` files"""
 
     @classmethod
-    def from_file(self, in_file):
+    def from_file(cls, in_file):
         if not hasattr(in_file, 'read'):
             in_file = open(in_file, 'r')
 
@@ -28,10 +30,14 @@ class ToxConfig(object):
             config_parser.readfp(in_file)
 
         return ToxConfig(
-            envlist=list(map(str.strip, config_parser.get('tox', 'envlist').split(','))),
+            envlist=cls._get_envlist_from_tox(in_file.name),
             commands=config_parser.get('testenv', 'commands')
         )
 
+    @classmethod
+    def _get_envlist_from_tox(cls, in_file):
+        tox_l_output = subprocess.check_output(['tox', '-c', in_file, '-l'])
+        return tox_l_output.splitlines()
 
     def __init__(self, envlist, commands):
         """Create an object from a list of environments and a list of


### PR DESCRIPTION
This makes `panci --to travis tox.ini` work with `tox.ini` files that use the [generative envlist](http://tox.readthedocs.org/en/latest/config.html#generative-envlist) feature of tox.

Fixes: GH-13

```
[marca@marca-mac2 python-panci]$ mkdir django-tags-input; curl -o django-tags-input/tox.ini https://raw.githubusercontent.com/WoLpH/django-tags-input/master/tox.ini
######################################################################## 100.0%

[marca@marca-mac2 python-panci]$ panci --to travis django-tags-input/tox.ini
language: python
env:
  - TOXENV=coveralls
  - TOXENV=py26-django14
  - TOXENV=py26-django15
  - TOXENV=py26-django16
  - TOXENV=py27-django14
  - TOXENV=py27-django15
  - TOXENV=py27-django16
  - TOXENV=py27-django18
  - TOXENV=pypy-django14
  - TOXENV=pypy-django15
  - TOXENV=pypy-django16
  - TOXENV=pypy-django18
  - TOXENV=py32-django15
  - TOXENV=py32-django16
  - TOXENV=py32-django18
  - TOXENV=py33-django15
  - TOXENV=py33-django16
  - TOXENV=py33-django18
  - TOXENV=py34-django15
  - TOXENV=py34-django16
  - TOXENV=py34-django18
  - TOXENV=pypy3-django15
  - TOXENV=pypy3-django16
  - TOXENV=pypy3-django18
install:
  - travis_retry pip install tox==1.6.1
script:
  - travis_retry tox
```

Thanks to @maikhoepfel for the idea to use the output of `tox -l`!